### PR TITLE
Add initial support for Home Manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,25 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1671958483,
+        "narHash": "sha256-wX+VBdHwrpW654PzmM4efiPdUDI8da8TGZeQt/zYP40=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "939731b8cb75fb451170cb8f935186a6a7424444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1602411953,
@@ -32,9 +51,41 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1671200928,
+        "narHash": "sha256-mZfzDyzojwj6I0wyooIjGIn81WtGVnx6+avU5Wv+VKU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "757b82211463dd5ba1475b6851d3731dfe14d377",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "darwin": "darwin"
+        "darwin": "darwin",
+        "home-manager": "home-manager"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,10 @@
 
  inputs = {
    darwin.url = "github:LnL7/nix-darwin";
+   home-manager.url = "github:nix-community/home-manager";
  };
 
- outputs = { self, darwin }: {
+ outputs = { self, darwin, home-manager }: {
    lib = pkgs: {
      # TODO: validate opts
      spec = opts: pkgs.writeText "cachix-deploy.json" (builtins.toJSON opts);
@@ -16,6 +17,13 @@
          module
        ];
      }).system;
+
+     homeManager = { extraSpecialArgs ? { } }: module: let
+       result = home-manager.lib.homeManagerConfiguration {
+         inherit pkgs extraSpecialArgs;
+         modules = [ module ];
+       };
+     in result.config.home.activationPackage;
    };
  };
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
      darwin = module: (darwin.lib.darwinSystem {
        system = pkgs.system;
        modules = [
-         (darwin + "/pkgs/darwin-installer/installer.nix") 
+         (darwin + "/pkgs/darwin-installer/installer.nix")
          module
        ];
      }).system;


### PR DESCRIPTION
Makes it possible to define a Home Manager deployment specification. For example

``` nix
cachix-deploy-lib.spec {
  agents = {
    "hm-test" = cachix-deploy-lib.homeManager { } (
      { pkgs, ... }:

      {
        home = {
          username = "user";
          homeDirectory = "/home/user";
          stateVersion = "22.05";
          packages = [ pkgs.hello ];
        };

        # Let Home Manager install and manage itself.
        programs.home-manager.enable = true;

        services.cachix-agent = {
          enable = true;
          name = "hm-test";
        };
      }
    );
  };
}
```

Note, not fit for merge yet.